### PR TITLE
manually attach environment controls for child views

### DIFF
--- a/Sources/Storybook/Views/StorybookCollection.swift
+++ b/Sources/Storybook/Views/StorybookCollection.swift
@@ -8,6 +8,7 @@ public struct StorybookCollection: View {
     @State var selectedView: StoryBookView?
     @State var collection: StorybookCollectionData = Storybook.build()
     @State var searchText = ""
+    @Environment(\.storybookControls) private var envControls
     let embedInNav: Bool
     
     public init(embedInNav: Bool = true) {
@@ -40,6 +41,7 @@ public struct StorybookCollection: View {
     private func navLink(for entry: StorybookEntry) -> some View {
         NavigationLink(destination: {
             StorybookDestinationView(destinations: entry.destinations)
+                .environment(\.storybookControls, envControls)
                 .navigationBarTitle(entry.title)
         }, label: {
             rowLabel(title: entry.title, file: entry.file)
@@ -103,6 +105,7 @@ public struct StorybookCollection: View {
         }
         .sheet(item: $selectedView, onDismiss: nil, content: { view in
             previewContent(for: view)
+                .environment(\.storybookControls, envControls)
         })
     }
 }

--- a/Sources/Storybook/Views/StorybookCollectionMac.swift
+++ b/Sources/Storybook/Views/StorybookCollectionMac.swift
@@ -9,6 +9,7 @@ public struct StorybookCollection: View {
     @State var selectedView: StoryBookView?
     @State var collection: StorybookCollectionData = Storybook.build()
     @State var searchText = ""
+    @Environment(\.storybookControls) private var envControls
     let embedInNav: Bool
     
     public init(embedInNav: Bool = true) {
@@ -40,6 +41,7 @@ public struct StorybookCollection: View {
     private func navLink(for entry: StorybookEntry) -> some View {
         NavigationLink(destination: {
             StorybookDestinationView(destinations: entry.destinations)
+                .environment(\.storybookControls, envControls)
         }, label: {
             rowLabel(title: entry.title, file: entry.file)
         })
@@ -105,6 +107,7 @@ public struct StorybookCollection: View {
         }
         .sheet(item: $selectedView, onDismiss: nil, content: { view in
             previewContent(for: view)
+                .environment(\.storybookControls, envControls)
         })
     }
 }

--- a/Sources/Storybook/Views/StorybookEntryView.swift
+++ b/Sources/Storybook/Views/StorybookEntryView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct StorybookDestinationView: View {
     
     let destinations: [StorybookEntry.Destination]
+    @Environment(\.storybookControls) private var envControls
     @State private var selectedView: StoryBookView?
     
     func rowLabel(title: String, file: String?) -> some View {
@@ -51,9 +52,11 @@ struct StorybookDestinationView: View {
         NavigationLink(destination: {
             #if os(iOS)
                 StorybookDestinationView(destinations: entry.destinations)
+                    .environment(\.storybookControls, envControls)
                     .navigationBarTitle(entry.title)
             #else
                 StorybookDestinationView(destinations: entry.destinations)
+                    .environment(\.storybookControls, envControls)
             #endif
         }, label: {
             rowLabel(title: entry.title, file: entry.file)
@@ -73,6 +76,7 @@ struct StorybookDestinationView: View {
         }
         .sheet(item: $selectedView, onDismiss: nil, content: { view in
             previewContent(for: view)
+                .environment(\.storybookControls, envControls)
         })
     }
 }


### PR DESCRIPTION
When used in packages for some reason the environment values are being lost, when manually attaching to content pushed in the nav stack or sheets it then works