### PR TITLE
add tagging functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 This package is a micro framework for rendering previews of components in a Storybook like fashion. It takes advantage of objc runtime and SwiftUI to make using it as seamless as possible. You do not need to be using SwiftUI in your app to use this, UIKit apps can also take advantage of this framework ([UIKit helper library](https://github.com/aj-bartocci/SwiftUIPreviewHelpers)).
 
-Version 2.0.0 is now ready. This brings some major new features and quality of life improments. These include:
+Version 2.1.0 is now ready. Recent features include:
 
+**Version 2.1.0:**
+- **Tagging system** - Organize and filter components using tags. Add tags to pages or individual views for easy categorization and discovery.
+- **Auto-navigation for single search results** - When searching by tag returns exactly one result, the view automatically opens for instant verification.
+- **AI development workflow** - Claude skill available for rapid visual verification during AI-assisted development.
+
+**Version 2.0.0:**
 - Preview controls. Previews now come with an overlay for controls that interact with the previews. Built in controls include a dark mode toggle, dynamic font sizing, and adjusting the preview screen size. You can add your own custom controls as well.
 - New folder based system for organizing previews. When building out a lot of components it was difficult to keep things organized with the old system. You can now specify folder paths (path/to/some/component) in order to easily organize where the previews live in the Storybook UI.
 - **Removing the DEBUG restriction.** It has been handy to be able to ship Storybook with non production builds so designers can spot check individual components without needing to navigate into certain situations within a live app. It is now your responsibility to wrap Storybook related code in whatever macro you choose so that will prevent it from going to production.
@@ -276,6 +282,19 @@ The `addingPath` method creates a new folder by appending to the current path an
 ### Filtering by Tags
 
 In the Storybook UI, you can filter components by selecting tags from the tags view. This allows you to quickly find all components with specific tags, regardless of where they are in the folder hierarchy.
+
+## AI-Assisted Development
+
+For AI-assisted development workflows, a Claude skill is available in the `skills/` directory that provides a complete workflow for visually verifying SwiftUI views during development.
+
+The [verifying-with-storybook](skills/verifying-with-storybook/SKILL.md) skill includes:
+
+- **Launch argument setup** - Configure your app to launch directly into Storybook
+- **UUID-based tagging strategy** - Use unique tags for instant navigation to specific views
+- **Verification workflow** - Complete flow from tagging to visual verification
+- **Tag management** - Best practices for temporary dev tags vs permanent semantic tags
+
+This enables rapid visual verification during development: tag a view with a unique identifier, launch the app to Storybook, and automatically navigate to that specific view.
 
 ## Models
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,84 @@ extension Storybook {
 }
 ```
 
-## Models 
+## Tags
+Tags provide a way to organize and filter your components in Storybook. You can add tags to both pages and individual views, making it easy to find related components across your design system.
+
+### Adding Tags to Pages
+
+Tags can be added to a `StorybookPage` using the `tags` parameter in the initializer:
+
+```swift
+extension Storybook {
+    @objc static let button = StorybookPage(
+        folder: "/Design System/Buttons",
+        views: [
+            PrimaryButton().storybookTitle("Primary"),
+            SecondaryButton().storybookTitle("Secondary")
+        ],
+        tags: "button", "interactive", "core"
+    )
+}
+```
+
+### Adding Tags to Individual Views
+
+You can also add tags to individual views using the `storybookTags` modifier:
+
+```swift
+extension Storybook {
+    @objc static let buttons = StorybookPage(
+        folder: "/Design System/Buttons",
+        views: [
+            PrimaryButton()
+                .storybookTitle("Primary")
+                .storybookTags("primary", "cta"),
+            SecondaryButton()
+                .storybookTitle("Secondary")
+                .storybookTags("secondary")
+        ],
+        tags: "button", "interactive"
+    )
+}
+```
+
+You can also apply tags to an array of views:
+
+```swift
+let views = [
+    SomeView().storybookTitle("View 1"),
+    SomeView().storybookTitle("View 2")
+].storybookTags("common-tag", "shared")
+```
+
+### Using StorybookFolder with Tags
+
+The `StorybookFolder` helper makes it easy to reuse folder paths and tags across multiple pages:
+
+```swift
+let designSystem = StorybookFolder(
+    name: "/Design System",
+    tags: "core", "design-system"
+)
+
+extension Storybook {
+    @objc static let buttons = StorybookPage(
+        folder: designSystem.addingPath("/Buttons", tags: "interactive"),
+        views: [
+            PrimaryButton().storybookTitle("Primary"),
+            SecondaryButton().storybookTitle("Secondary")
+        ]
+    )
+}
+```
+
+The `addingPath` method creates a new folder by appending to the current path and merging tags.
+
+### Filtering by Tags
+
+In the Storybook UI, you can filter components by selecting tags from the tags view. This allows you to quickly find all components with specific tags, regardless of where they are in the folder hierarchy.
+
+## Models
 
 __Storybook__
 

--- a/Sources/Storybook/PreviewAdditions/ControlledPreview+Utils.swift
+++ b/Sources/Storybook/PreviewAdditions/ControlledPreview+Utils.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @available(iOS 13, *)
 @available(macOS 11, *)
 public class PreviewActions: ObservableObject {
-    @Published private (set) var message: String?
+    @Published private(set) var message: String?
     
     public func tappedButton(message: String) {
         self.message = message

--- a/Sources/Storybook/Storybook.swift
+++ b/Sources/Storybook/Storybook.swift
@@ -32,9 +32,19 @@ public class Storybook: NSObject {
                     continue
                 }
                 if let directory = preview.directory {
-                    data.addEntry(folder: directory, views: preview.views, file: preview.file)
+                    data.addEntry(
+                        folder: directory,
+                        views: preview.views,
+                        tags: preview.tags,
+                        file: preview.file
+                    )
                 } else {
-                    data.addEntry(folder: "\(preview.chapter)/\(preview.title)", views: preview.views, file: preview.file)
+                    data.addEntry(
+                        folder: "\(preview.chapter)/\(preview.title)",
+                        views: preview.views,
+                        tags: preview.tags,
+                        file: preview.file
+                    )
                 }
             }
         }

--- a/Sources/Storybook/StorybookCollectionData.swift
+++ b/Sources/Storybook/StorybookCollectionData.swift
@@ -41,7 +41,9 @@ class StorybookEntry: Identifiable {
 //        return files.sorted().joined(separator: ",")
         return nil
     }
+    let tags: Set<String>
     var files = Set<String>()
+    var isFolder = false
     
     /// Used for rendering UI after the data has been built up
     lazy var destinations: [Destination] = {
@@ -55,35 +57,57 @@ class StorybookEntry: Identifiable {
         return destinations.map { destination in
             switch destination {
             case .view(let view):
-                return StorybookEntry(title: view.title, children: [:], views: [view], file: view.file)
+                return StorybookEntry(
+                    id: view.id.uuidString,
+                    title: view.title,
+                    children: [:],
+                    views: [view],
+                    tags: tags.union(view.tags),
+                    file: view.file
+                )
             case .entry(let entry):
                 return entry
             }
         }
     }()
     
-    let id = UUID().uuidString
+    let id: String
     
     init(
+        id: String,
         title: String,
         children: [String: StorybookEntry],
         views: [StoryBookView],
+        tags: Set<String>,
         file: String? = nil
     ) {
+        self.id = id
         self.title = title
         self.children = children
         self.views = views
+        let _tags = tags.map({ $0.lowercased() })
+        self.tags = Set(_tags)
         if let file = file {
             self.files.insert(file)
         }
     }
 }
 
+private extension DispatchQueue {
+    static let storybookCollection = DispatchQueue(label: "com.ajbartocci.storybookCollection.queue")
+}
+
 @available(iOS 13.0, *)
 @available(macOS 11, *)
 class StorybookCollectionData {
-    var root = [String: StorybookEntry]()
+    private var root = [String: StorybookEntry]()
+    private var tags = Set<String>()
     
+    lazy var sortedTags: [String] = {
+        tags.sorted()
+    }()
+    
+    // TODO: rename this to rootEntries
     /// Used for rendering UI after the data has been built up
     lazy var sortedEntries: [StorybookEntry] = {
         return root.values.sorted { lhs, rhs in
@@ -104,9 +128,11 @@ class StorybookCollectionData {
                 switch destination {
                 case .view(let storyBookView):
                     arr.append(StorybookEntry(
+                        id: storyBookView.id.uuidString,
                         title: storyBookView.title,
                         children: [:],
                         views: [storyBookView],
+                        tags: storyBookView.tags,
                         file: storyBookView.file
                     ))
                 case .entry(let storybookEntry):
@@ -117,12 +143,13 @@ class StorybookCollectionData {
         for entry in sortedEntries {
             flattenEntry(entry, into: &flattened)
         }
-        return flattened
+        return flattened.sorted(by: { $0.title < $1.title }) 
     }()
     
     func addEntry(
         folder directory: String,
         views: [StoryBookView],
+        tags: Set<String>,
         file: String = #file
     ) {
         var directory = directory.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -137,10 +164,16 @@ class StorybookCollectionData {
             // nothing provided, need to show error
             paths = ["* Uncategorized"]
         }
+        // could combine tags here by recreating the views with the tags
+        let views = views.map { view in
+            return StorybookView(title: view.title, tags: view.tags.union(tags), view: view.view, file: view.file)
+        }
+        self.tags.formUnion(tags)
         addEntry(
             paths: paths,
             entryDirectory: &root,
             views: views,
+            tags: tags,
             file: file
         )
     }
@@ -149,6 +182,7 @@ class StorybookCollectionData {
         paths: [String],
         entryDirectory: inout [String: StorybookEntry],
         views: [StoryBookView],
+        tags: Set<String>,
         file: String = #file
     ) {
         let entry: StorybookEntry
@@ -157,13 +191,16 @@ class StorybookCollectionData {
             entry = existing
         } else {
             entry = StorybookEntry(
+                id: UUID().uuidString,
                 title: title,
                 children: [:],
-                views: []
+                views: [],
+                tags: tags
             )
             entryDirectory[title] = entry
         }
         entry.files.insert(file)
+        entry.isFolder = true
         if paths.count == 1 {
             // at the leaf node so append the views
             entry.views.append(contentsOf: views)
@@ -173,17 +210,66 @@ class StorybookCollectionData {
                 paths: Array(paths.dropFirst()),
                 entryDirectory: &entry.children,
                 views: views,
+                tags: tags,
                 file: file
             )
         }
     }
     
-    func entriesMatchingSearch(_ keyword: String) -> [StorybookEntry] {
+    func search(_ keyword: String, completion: @escaping ([StorybookEntry]) -> Void) {
+        let keyword = keyword.lowercased()
         if keyword.isEmpty {
-            return sortedEntries
+            completion(sortedEntries)
         } else {
-            return flattenedEntries.filter { entry in
-                return entry.title.lowercased().contains(keyword.lowercased())
+            DispatchQueue.storybookCollection.async { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                let entries: [StorybookEntry]
+                if keyword.first == "#" {
+                    let tags = Set(keyword.split(separator: ",").compactMap({
+                        let keyword: String
+                        if $0.first == "#" {
+                            keyword = $0.dropFirst().trimmingCharacters(in: .whitespaces)
+                        } else {
+                            keyword = $0.trimmingCharacters(in: .whitespaces)
+                        }
+                        if !keyword.isEmpty {
+                            return keyword
+                        } else {
+                            return nil
+                        }
+                    }))
+                    if tags.isEmpty {
+                        // show all with tags
+                        entries = flattenedEntries.filter { entry in
+                            return !entry.isFolder && !entry.tags.isEmpty
+                        }
+                    } else if tags.count == 1, let tag = tags.first {
+                        // single tag
+                        // show only matching tags
+                        entries = flattenedEntries.filter { entry in
+                            return !entry.isFolder && entry.tags.contains(where: { $0.contains(tag) })
+                        }
+                    } else {
+                        // multi tag
+                        // nested for loops are not ideal but whatever for now
+                        entries = flattenedEntries.filter { entry in
+                            return !entry.isFolder && entry.tags.contains(where: { entryTag in
+                                tags.contains { tag in
+                                    entryTag.contains(tag)
+                                }
+                            })
+                        }
+                    }
+                } else {
+                    entries = flattenedEntries.filter { entry in
+                        return entry.title.lowercased().contains(keyword.lowercased())
+                    }
+                }
+                DispatchQueue.main.async {
+                    completion(entries)
+                }
             }
         }
     }

--- a/Sources/Storybook/StorybookCollectionData.swift
+++ b/Sources/Storybook/StorybookCollectionData.swift
@@ -100,7 +100,7 @@ private extension DispatchQueue {
 @available(iOS 13.0, *)
 @available(macOS 11, *)
 class StorybookCollectionData {
-    private var root = [String: StorybookEntry]()
+    private(set) var root = [String: StorybookEntry]()
     private var tags = Set<String>()
     
     lazy var sortedTags: [String] = {

--- a/Sources/Storybook/Views/SearchBar.swift
+++ b/Sources/Storybook/Views/SearchBar.swift
@@ -9,12 +9,15 @@ struct SearchBar: UIViewRepresentable {
     
     func makeUIView(context: Context) -> UISearchBar {
         let searchBar = UISearchBar()
+        searchBar.placeholder = "Search - use # for tags"
         searchBar.delegate = context.coordinator
         return searchBar
     }
     
     func updateUIView(_ searchBar: UISearchBar, context: Context) {
-        
+        if searchBar.text != searchText {
+            searchBar.text = searchText
+        }
     }
     
     func makeCoordinator() -> Coordinator {
@@ -49,13 +52,16 @@ struct SearchBar: NSViewRepresentable {
     
     func makeNSView(context: Context) -> NSSearchField {
         let searchBar = NSSearchField()
+        searchBar.placeholderString = "Search - use # for tags"
         searchBar.delegate = context.coordinator
         context.coordinator.searchBar = searchBar
         return searchBar
     }
     
-    func updateNSView(_ nsView: NSSearchField, context: Context) {
-        
+    func updateNSView(_ searchBar: NSSearchField, context: Context) {
+        if searchBar.stringValue != searchText {
+            searchBar.stringValue = searchText
+        }
     }
     
     func makeCoordinator() -> Coordinator {

--- a/Sources/Storybook/Views/StorybookCollectionMac.swift
+++ b/Sources/Storybook/Views/StorybookCollectionMac.swift
@@ -3,12 +3,8 @@
 import SwiftUI
 
 @available(macOS 11, *)
-public struct StorybookCollection: View {
-    
-    @State var selectedItem: StorybookPage?
-    @State var selectedView: StoryBookView?
-    @State var collection: StorybookCollectionData = Storybook.build()
-    @State var searchText = ""
+private struct _StorybookCollection: View {
+    @EnvironmentObject private var viewModel: StorybookCollectionViewModel
     @Environment(\.storybookControls) private var envControls
     let embedInNav: Bool
     
@@ -17,7 +13,7 @@ public struct StorybookCollection: View {
     }
     
     public var body: some View {
-        if collection.sortedEntries.count == 0 {
+        if viewModel.showNoPagesError {
             noPagesMessage()
         } else {
             if embedInNav {
@@ -98,17 +94,50 @@ public struct StorybookCollection: View {
         
     private func listContent() -> some View {
         VStack {
-            SearchBar(searchText: $searchText)
+            SearchBar(searchText: $viewModel.searchText)
             List {
-                ForEach(collection.entriesMatchingSearch(searchText)) { entry in
-                    navContent(for: entry)
+                if !viewModel.isSearching {
+                    ForEach(viewModel.entries) { entry in
+                        navLink(for: entry)
+                    }
+                } else {
+                    ForEach(viewModel.entries) { entry in
+                        if entry.destinations.count == 1 {
+                            switch entry.destinations[0] {
+                            case .entry(let entry):
+                                navLink(for: entry)
+                            case .view(let storybookView):
+                                navLink(for: storybookView)
+                            }
+                        } else {
+                            navLink(for: entry)
+                        }
+                    }
                 }
             }
         }
-        .sheet(item: $selectedView, onDismiss: nil, content: { view in
+        .sheet(item: $viewModel.selectedView, onDismiss: nil, content: { view in
             previewContent(for: view)
                 .environment(\.storybookControls, envControls)
         })
+        .sheet(isPresented: $viewModel.showTagsSelector) {
+            TagsView(selectedTags: $viewModel.selectedTags, tags: viewModel.allTags)
+        }
+    }
+}
+
+@available(macOS 11, *)
+public struct StorybookCollection: View {
+    @State private var viewModel = StorybookCollectionViewModel()
+    let embedInNav: Bool
+        
+    public init(embedInNav: Bool = true) {
+        self.embedInNav = embedInNav
+    }
+    
+    public var body: some View {
+        _StorybookCollection(embedInNav: embedInNav)
+            .environmentObject(viewModel)
     }
 }
 #endif

--- a/Sources/Storybook/Views/StorybookCollectionViewModel.swift
+++ b/Sources/Storybook/Views/StorybookCollectionViewModel.swift
@@ -1,0 +1,123 @@
+//
+//  StorybookCollectionViewModel.swift
+//  Storybook
+//
+//  Created by AJ Bartocci on 12/2/25.
+//
+
+import Combine
+import Foundation
+
+@available(iOS 13.0, *)
+@available(macOS 11, *)
+class StorybookCollectionViewModel: ObservableObject {
+    @Published var selectedView: StoryBookView?
+    @Published var searchText = ""
+    @Published var selectedTags = Set<String>()
+    @Published var showTagsSelector = false
+    @Published private(set) var entries = [StorybookEntry]()
+    private var isUpdatingFromSearch = false
+    private var collection: StorybookCollectionData = Storybook.build()
+    private var cancellables = Set<AnyCancellable>()
+    
+    var allTags: [String] {
+        collection.sortedTags
+    }
+    
+    var showNoPagesError: Bool {
+        entries.isEmpty && searchText.isEmpty
+    }
+    
+    var isSearching: Bool {
+        !searchText.isEmpty
+    }
+    
+    init() {
+        $selectedTags.sink { [weak self] selectedTags in
+            self?.updateSearchFromTags(selectedTags)
+        }
+        .store(in: &cancellables)
+        
+        $searchText
+        .debounce(for: 0.2, scheduler: RunLoop.main)
+        .removeDuplicates()
+        .sink { [weak self] searchText in
+            self?.updateFromTextInput(searchText)
+        }
+        .store(in: &cancellables)
+        
+        // When text clears, immediately update UI rather than debouncing
+        $searchText.sink { [weak self] searchText in
+            if searchText.isEmpty {
+                self?.updateFromTextInput(searchText)
+            }
+        }
+        .store(in: &cancellables)
+        
+        self.entries = collection.sortedEntries
+    }
+    
+    private func updateFromTextInput(_ searchText: String) {
+        isUpdatingFromSearch = true
+        updateTagsFromSearch(searchText)
+        collection.search(searchText, completion: { [weak self] entries in
+            self?.entries = entries
+        })
+        isUpdatingFromSearch = false
+    }
+    
+    private func updateSearchFromTags(_ tags: Set<String>) {
+        // Ugly logic here but can clean it up later
+        guard !isUpdatingFromSearch else {
+            return
+        }
+        let searchTags = parseTags(from: searchText)
+        // For adding new tag selections to search text
+        for tag in tags {
+            // if the tag is not in the search text already then append it
+            if !searchTags.contains(tag) {
+                let prefix: String = {
+                    if searchText.isEmpty {
+                        return "#"
+                    } else {
+                        return ",#"
+                    }
+                }()
+                searchText.append(prefix + tag)
+            }
+        }
+        // For removing tags from search text
+        var newSearch = searchText
+        for tag in searchTags {
+            if !tags.contains(tag) {
+                newSearch = newSearch.replacingOccurrences(of: ", #"+tag, with: "")
+                newSearch = newSearch.replacingOccurrences(of: ",#"+tag, with: "")
+                newSearch = newSearch.replacingOccurrences(of: "#"+tag, with: "")
+            }
+        }
+        searchText = newSearch
+    }
+    
+    private func parseTags(from search: String) -> Set<String> {
+        let potentialTags = search.split(separator: ",")
+        var tags = Set<String>()
+        potentialTags.forEach { value in
+            let value = value.trimmingCharacters(in: .whitespaces)
+            if value.first == "#" {
+                let trimmed = value.dropFirst()
+                if !trimmed.isEmpty {
+                    tags.insert(String(trimmed))
+                }
+            }
+        }
+        return tags
+    }
+    
+    private func updateTagsFromSearch(_ search: String) {
+        let newTags = parseTags(from: search)
+        guard selectedTags != newTags else {
+            return
+        }
+        selectedTags = newTags
+    }
+}

--- a/Sources/Storybook/Views/StorybookCollectionViewModel.swift
+++ b/Sources/Storybook/Views/StorybookCollectionViewModel.swift
@@ -60,8 +60,18 @@ class StorybookCollectionViewModel: ObservableObject {
     private func updateFromTextInput(_ searchText: String) {
         isUpdatingFromSearch = true
         updateTagsFromSearch(searchText)
+        let isTagSearch = searchText.trimmingCharacters(in: .whitespaces).first == "#"
         collection.search(searchText, completion: { [weak self] entries in
             self?.entries = entries
+
+            // Auto-navigate to single result when searching by tag
+            if isTagSearch && entries.count == 1 {
+                let entry = entries[0]
+                // Check if this single entry has only one view
+                if entry.views.count == 1, let view = entry.views.first {
+                    self?.selectedView = view
+                }
+            }
         })
         isUpdatingFromSearch = false
     }

--- a/Sources/Storybook/Views/StorybookFolder.swift
+++ b/Sources/Storybook/Views/StorybookFolder.swift
@@ -1,0 +1,30 @@
+//
+//  StorybookFolder.swift
+//  Storybook
+//
+//  Created by AJ Bartocci on 6/26/25.
+//
+
+#if canImport(SwiftUI)
+import Foundation
+
+@available(iOS 13.0, *)
+@available(macOS 11, *)
+public struct StorybookFolder {
+    let path: String
+    let tags: Set<String>
+    
+    init(_ path: String, tags: Set<String>) {
+        self.path = path
+        self.tags = tags
+    }
+    
+    public init(name path: String, tags: String...) {
+        self.init(path, tags: Set(tags))
+    }
+    
+    public func addingPath(_ path: String, tags: String...) -> StorybookFolder {
+        StorybookFolder(self.path + path, tags: self.tags.union(Set(tags)))
+    }
+}
+#endif

--- a/Sources/Storybook/Views/TagsView.swift
+++ b/Sources/Storybook/Views/TagsView.swift
@@ -1,0 +1,45 @@
+//
+//  TagsView.swift
+//  Storybook
+//
+//  Created by AJ Bartocci on 7/3/25.
+//
+
+#if canImport(SwiftUI)
+import SwiftUI
+
+@available(iOS 13.0, *)
+@available(macOS 11, *)
+struct TagsView: View {
+    @Binding var selectedTags: Set<String>
+    let tags: [String]
+    
+    var body: some View {
+        NavigationView {
+            List(tags, id: \.self) { tag in
+                HStack {
+                    if selectedTags.contains(tag) {
+                        Image(systemName: "checkmark.circle")
+                            .foregroundColor(Color.blue)
+                    }
+                    Text(tag)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+                .internalSubtitleFont()
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if selectedTags.contains(tag) {
+                        selectedTags.remove(tag)
+                    } else {
+                        selectedTags.insert(tag)
+                    }
+                }
+            }
+            #if os(iOS)
+            .navigationBarTitle("Tags")
+            #endif
+        }
+    }
+}
+#endif

--- a/Tests/StorybookTests/StorybookCollectionDataTests.swift
+++ b/Tests/StorybookTests/StorybookCollectionDataTests.swift
@@ -20,25 +20,29 @@ final class StorybookCollectionDataTests: XCTestCase {
             folder: "root/path1",
             views: [
                 Text("Foo").storybookTitle("Preview 1"),
-            ]
+            ],
+            tags: Set()
         )
         sut.addEntry(
             folder: "/root/path1/",
             views: [
                 Text("Foo").storybookTitle("Preview 2")
-            ]
+            ],
+            tags: Set()
         )
         sut.addEntry(
             folder: "/root/path1",
             views: [
                 Text("Foo").storybookTitle("Preview 3")
-            ]
+            ],
+            tags: Set()
         )
         sut.addEntry(
             folder: "root/path1/",
             views: [
                 Text("Foo").storybookTitle("Preview 4"),
-            ]
+            ],
+            tags: Set()
         )
         let destination = sut.root["root"]?.children["path1"]
         XCTAssertEqual(destination?.views.count, 4)
@@ -48,15 +52,18 @@ final class StorybookCollectionDataTests: XCTestCase {
         let sut = StorybookCollectionData()
         sut.addEntry(
             folder: "/",
-            views: [ Text("Foo").storybookTitle("Preview 1") ]
+            views: [ Text("Foo").storybookTitle("Preview 1") ],
+            tags: Set()
         )
         sut.addEntry(
             folder: "",
-            views: [ Text("Foo").storybookTitle("Preview 2") ]
+            views: [ Text("Foo").storybookTitle("Preview 2") ],
+            tags: Set()
         )
         sut.addEntry(
             folder: " ",
-            views: [ Text("Foo").storybookTitle("Preview 3") ]
+            views: [ Text("Foo").storybookTitle("Preview 3") ],
+            tags: Set()
         )
         let views = sut.root["* Uncategorized"]?.views
         XCTAssertEqual(views?.count, 3)
@@ -69,7 +76,8 @@ final class StorybookCollectionDataTests: XCTestCase {
             views: [
                 Text("Foo").storybookTitle("Preview 1"),
                 Text("Foo").storybookTitle("Preview 2")
-            ]
+            ],
+            tags: Set()
         )
         let root = sut.root["root"]
         XCTAssertEqual(root?.views.count, 2)
@@ -82,14 +90,16 @@ final class StorybookCollectionDataTests: XCTestCase {
             views: [
                 Text("Foo").storybookTitle("Preview 1"),
                 Text("Foo").storybookTitle("Preview 2")
-            ]
+            ],
+            tags: Set()
         )
         sut.addEntry(
             folder: "/root/",
             views: [
                 Text("Foo").storybookTitle("Preview 3"),
                 Text("Foo").storybookTitle("Preview 4")
-            ]
+            ],
+            tags: Set()
         )
         let root = sut.root["root"]
         XCTAssertEqual(root?.views.count, 4)
@@ -102,7 +112,8 @@ final class StorybookCollectionDataTests: XCTestCase {
             views: [
                 Text("Foo").storybookTitle("Preview 1"),
                 Text("Foo").storybookTitle("Preview 2")
-            ]
+            ],
+            tags: Set()
         )
         let root = sut.root["root"]
         XCTAssertEqual(root?.views.count, 0)
@@ -119,14 +130,16 @@ final class StorybookCollectionDataTests: XCTestCase {
             views: [
                 Text("Foo").storybookTitle("Preview 1"),
                 Text("Foo").storybookTitle("Preview 2")
-            ]
+            ],
+            tags: Set()
         )
         sut.addEntry(
             folder: "/root/path1/path2/",
             views: [
                 Text("Foo").storybookTitle("Preview 3"),
                 Text("Foo").storybookTitle("Preview 4")
-            ]
+            ],
+            tags: Set()
         )
         let root = sut.root["root"]
         XCTAssertEqual(root?.views.count, 0)
@@ -143,14 +156,16 @@ final class StorybookCollectionDataTests: XCTestCase {
             views: [
                 Text("Foo").storybookTitle("Preview 1"),
                 Text("Foo").storybookTitle("Preview 2")
-            ]
+            ],
+            tags: Set()
         )
         sut.addEntry(
             folder: "/root/path1/",
             views: [
                 Text("Foo").storybookTitle("Preview 3"),
                 Text("Foo").storybookTitle("Preview 4")
-            ]
+            ],
+            tags: Set()
         )
         let root = sut.root["root"]
         XCTAssertEqual(root?.views.count, 0)
@@ -159,6 +174,14 @@ final class StorybookCollectionDataTests: XCTestCase {
         let path2 = path1?.children["path2"]
         XCTAssertEqual(path2?.views.count, 2)
     }
+    
+    // making sure tags on the parent entry get added to the views
+    
+    // add tests for search
+    // - no tags
+        // - folder and component results
+    // - tags
+        // only component results
     
     // Took this functionality out but might add it back
 //    func test_addEntry_AddsFileToLeafNode() throws {

--- a/Tests/StorybookTests/StorybookCollectionDataTests.swift
+++ b/Tests/StorybookTests/StorybookCollectionDataTests.swift
@@ -175,14 +175,246 @@ final class StorybookCollectionDataTests: XCTestCase {
         XCTAssertEqual(path2?.views.count, 2)
     }
     
-    // making sure tags on the parent entry get added to the views
-    
-    // add tests for search
-    // - no tags
-        // - folder and component results
-    // - tags
-        // only component results
-    
+    // MARK: - Tag Tests
+
+    func test_addEntry_ParentTagsMergeWithViewTags() throws {
+        let sut = StorybookCollectionData()
+        sut.addEntry(
+            folder: "/root/path1",
+            views: [
+                Text("Foo")
+                    .storybookTitle("Preview 1")
+                    .storybookTags("view-tag-1", "view-tag-2"),
+                Text("Bar")
+                    .storybookTitle("Preview 2")
+                    .storybookTags("view-tag-3")
+            ],
+            tags: Set(["parent-tag-1", "parent-tag-2"])
+        )
+        let entry = sut.root["root"]?.children["path1"]
+        XCTAssertNotNil(entry)
+        XCTAssertEqual(entry?.views.count, 2)
+
+        // Check that first view has both parent and view tags
+        let view1 = entry?.views[0]
+        XCTAssertTrue(view1?.tags.contains("parent-tag-1") ?? false)
+        XCTAssertTrue(view1?.tags.contains("parent-tag-2") ?? false)
+        XCTAssertTrue(view1?.tags.contains("view-tag-1") ?? false)
+        XCTAssertTrue(view1?.tags.contains("view-tag-2") ?? false)
+
+        // Check that second view has both parent and view tags
+        let view2 = entry?.views[1]
+        XCTAssertTrue(view2?.tags.contains("parent-tag-1") ?? false)
+        XCTAssertTrue(view2?.tags.contains("parent-tag-2") ?? false)
+        XCTAssertTrue(view2?.tags.contains("view-tag-3") ?? false)
+    }
+
+    func test_addEntry_ViewsWithoutTags_ReceiveOnlyParentTags() throws {
+        let sut = StorybookCollectionData()
+        sut.addEntry(
+            folder: "/root/components",
+            views: [
+                Text("Foo").storybookTitle("Preview 1"),
+                Text("Bar").storybookTitle("Preview 2")
+            ],
+            tags: Set(["parent-tag"])
+        )
+        let entry = sut.root["root"]?.children["components"]
+        XCTAssertNotNil(entry)
+
+        let view1 = entry?.views[0]
+        XCTAssertEqual(view1?.tags.count, 1)
+        XCTAssertTrue(view1?.tags.contains("parent-tag") ?? false)
+
+        let view2 = entry?.views[1]
+        XCTAssertEqual(view2?.tags.count, 1)
+        XCTAssertTrue(view2?.tags.contains("parent-tag") ?? false)
+    }
+
+    // MARK: - Search Tests
+
+    func test_search_NoTags_ReturnsBothFoldersAndComponents() throws {
+        let sut = StorybookCollectionData()
+        sut.addEntry(
+            folder: "/Design System/Buttons",
+            views: [
+                Text("Foo").storybookTitle("Primary Button"),
+                Text("Bar").storybookTitle("Secondary Button")
+            ],
+            tags: Set(["button"])
+        )
+        sut.addEntry(
+            folder: "/Design System/Cards",
+            views: [
+                Text("Baz").storybookTitle("Card Component")
+            ],
+            tags: Set(["card"])
+        )
+
+        let expectation = XCTestExpectation(description: "Search completes")
+        sut.search("Button") { results in
+            // Should return both folder entries and component entries
+            // Results should include:
+            // - "Buttons" folder entry
+            // - "Primary Button" component
+            // - "Secondary Button" component
+            XCTAssertGreaterThan(results.count, 0)
+
+            // Check that we have results with "Button" in the title
+            let hasButtonResults = results.contains { entry in
+                entry.title.contains("Button")
+            }
+            XCTAssertTrue(hasButtonResults)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func test_search_WithSingleTag_ReturnsOnlyMatchingComponents() throws {
+        let sut = StorybookCollectionData()
+        sut.addEntry(
+            folder: "/Components/Buttons",
+            views: [
+                Text("Foo").storybookTitle("Primary Button"),
+                Text("Bar").storybookTitle("Secondary Button")
+            ],
+            tags: Set(["button", "interactive"])
+        )
+        sut.addEntry(
+            folder: "/Components/Cards",
+            views: [
+                Text("Baz").storybookTitle("Card Component")
+            ],
+            tags: Set(["card", "container"])
+        )
+
+        let expectation = XCTestExpectation(description: "Search completes")
+        sut.search("#button") { results in
+            // Should return only component entries (no folders) that have "button" tag
+            XCTAssertEqual(results.count, 2)
+
+            // All results should be non-folder entries
+            let allAreComponents = results.allSatisfy { !$0.isFolder }
+            XCTAssertTrue(allAreComponents)
+
+            // All results should have the "button" tag
+            let allHaveButtonTag = results.allSatisfy { entry in
+                entry.tags.contains("button")
+            }
+            XCTAssertTrue(allHaveButtonTag)
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func test_search_WithMultipleTags_ReturnsComponentsMatchingAnyTag() throws {
+        let sut = StorybookCollectionData()
+        sut.addEntry(
+            folder: "/Components/Buttons",
+            views: [
+                Text("Foo").storybookTitle("Primary Button")
+            ],
+            tags: Set(["button", "primary"])
+        )
+        sut.addEntry(
+            folder: "/Components/Links",
+            views: [
+                Text("Bar").storybookTitle("Text Link")
+            ],
+            tags: Set(["link", "interactive"])
+        )
+        sut.addEntry(
+            folder: "/Components/Cards",
+            views: [
+                Text("Baz").storybookTitle("Card Component")
+            ],
+            tags: Set(["card"])
+        )
+
+        let expectation = XCTestExpectation(description: "Search completes")
+        sut.search("#button,#link") { results in
+            // Should return components that match either "button" OR "link" tag
+            XCTAssertEqual(results.count, 2)
+
+            // All results should be non-folder entries
+            let allAreComponents = results.allSatisfy { !$0.isFolder }
+            XCTAssertTrue(allAreComponents)
+
+            // Should have button component and link component, but not card
+            let titles = results.map { $0.title }
+            XCTAssertTrue(titles.contains("Primary Button"))
+            XCTAssertTrue(titles.contains("Text Link"))
+            XCTAssertFalse(titles.contains("Card Component"))
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func test_search_WithHashOnly_ReturnsAllComponentsWithTags() throws {
+        let sut = StorybookCollectionData()
+        sut.addEntry(
+            folder: "/Components/Tagged",
+            views: [
+                Text("Foo").storybookTitle("Tagged Component")
+            ],
+            tags: Set(["some-tag"])
+        )
+        sut.addEntry(
+            folder: "/Components/Untagged",
+            views: [
+                Text("Bar").storybookTitle("Untagged Component")
+            ],
+            tags: Set()
+        )
+
+        let expectation = XCTestExpectation(description: "Search completes")
+        sut.search("#") { results in
+            // Should return only components that have any tags
+            XCTAssertEqual(results.count, 1)
+            XCTAssertEqual(results.first?.title, "Tagged Component")
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func test_search_EmptyKeyword_ReturnsRootEntries() throws {
+        let sut = StorybookCollectionData()
+        sut.addEntry(
+            folder: "/Root1/Child",
+            views: [
+                Text("Foo").storybookTitle("Component 1")
+            ],
+            tags: Set()
+        )
+        sut.addEntry(
+            folder: "/Root2/Child",
+            views: [
+                Text("Bar").storybookTitle("Component 2")
+            ],
+            tags: Set()
+        )
+
+        let expectation = XCTestExpectation(description: "Search completes")
+        sut.search("") { results in
+            // Should return only root level entries
+            XCTAssertEqual(results.count, 2)
+
+            let titles = results.map { $0.title }.sorted()
+            XCTAssertEqual(titles, ["Root1", "Root2"])
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
     // Took this functionality out but might add it back
 //    func test_addEntry_AddsFileToLeafNode() throws {
 //        let sut = StorybookCollectionData()

--- a/skills/verifying-with-storybook/SKILL.md
+++ b/skills/verifying-with-storybook/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: verifying-with-storybook
+description: Use when building or modifying SwiftUI views and need to visually verify the implementation matches requirements. Especially useful when implementing design specs, fixing UI bugs, or creating new components where visual correctness is critical.
+---
+
+# Verifying with Storybook
+
+## Overview
+
+Storybook-SwiftUI enables instant visual verification of SwiftUI views during development. Tag views with unique identifiers, launch the app directly to Storybook, and automatically navigate to the specific view being developed.
+
+**Core principle:** Visual verification should be as fast as running a test - tag it, launch it, see it.
+
+## When to Use
+
+Use this workflow when:
+- Implementing new SwiftUI views or components
+- Fixing UI bugs that require visual verification
+- Iterating on design implementations
+- Need to verify view appears correctly across different states
+
+Don't use when:
+- Pure logic changes with no UI impact
+- Working on backend/API code
+- Unit testing is sufficient for verification
+
+## Setup: Launch Arguments
+
+To enable direct launch to Storybook, configure your app's launch arguments:
+
+### 1. Add Launch Argument Handler
+
+In your app's entry point or SceneDelegate:
+
+```swift
+import Storybook
+import SwiftUI
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            if ProcessInfo.processInfo.arguments.contains("--storybook") {
+                Storybook.render()
+            } else {
+                ContentView()
+            }
+        }
+    }
+}
+```
+
+### 2. Configure Xcode Scheme
+
+Edit Scheme → Run → Arguments → Arguments Passed On Launch:
+- Add: `--storybook`
+- Leave unchecked by default
+- Check when you want to launch directly to Storybook
+
+**Tip:** Create a separate scheme called "Storybook" with this argument always enabled.
+
+## Tagging for Navigation
+
+### Use Unique Tags for Development
+
+When creating or modifying a view, add a unique tag using a UUID:
+
+```swift
+extension Storybook {
+    @objc static let myButton = StorybookPage(
+        folder: "/Design System/Buttons",
+        views: [
+            PrimaryButton()
+                .storybookTitle("Primary")
+                .storybookTags("dev-12a34b56")  // Unique tag for this session
+        ]
+    )
+}
+```
+
+**Why UUIDs work well:**
+- Guaranteed unique across all views
+- Easy to search (no conflicts)
+- Can be temporary (remove after verification)
+- Auto-navigate works (single result)
+
+### Generate UUID
+
+```bash
+# macOS/Linux
+uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8
+# Example: 3f1b16a2
+
+# Or in code
+UUID().uuidString.lowercased().prefix(8)
+```
+
+## Verification Workflow
+
+### Standard Flow
+
+```dot
+digraph verification_flow {
+    "Add unique tag to view" [shape=box];
+    "Build and run with --storybook" [shape=box];
+    "Search for tag" [shape=box];
+    "Auto-navigate?" [shape=diamond];
+    "View opens automatically" [shape=box];
+    "Tap result to open" [shape=box];
+    "Verify visually" [shape=box];
+    "Make changes" [shape=box];
+    "Hot reload or rebuild" [shape=box];
+    "Done?" [shape=diamond];
+    "Remove dev tag" [shape=box];
+    "Complete" [shape=box];
+
+    "Add unique tag to view" -> "Build and run with --storybook";
+    "Build and run with --storybook" -> "Search for tag";
+    "Search for tag" -> "Auto-navigate?";
+    "Auto-navigate?" -> "View opens automatically" [label="single result"];
+    "Auto-navigate?" -> "Tap result to open" [label="multiple"];
+    "View opens automatically" -> "Verify visually";
+    "Tap result to open" -> "Verify visually";
+    "Verify visually" -> "Done?";
+    "Done?" -> "Remove dev tag" [label="yes"];
+    "Done?" -> "Make changes" [label="no"];
+    "Make changes" -> "Hot reload or rebuild";
+    "Hot reload or rebuild" -> "Verify visually";
+    "Remove dev tag" -> "Complete";
+}
+```
+
+### Quick Reference
+
+| Step | Command/Action | Example |
+|------|---------------|---------|
+| Generate tag | `uuidgen \| tr '[:upper:]' '[:lower:]' \| cut -c1-8` | `dev-3f1b16a2` |
+| Add to view | `.storybookTags("dev-{uuid}")` | `.storybookTags("dev-3f1b16a2")` |
+| Launch | Enable `--storybook` argument and run | Xcode Run ▶ |
+| Navigate | Search `#{tag}` in Storybook | `#dev-3f1b16a2` |
+| Verify | View opens automatically if unique | Visual inspection |
+| Clean up | Remove dev tag before commit | Delete `.storybookTags()` line |
+
+## Complete Example
+
+**Scenario:** Building a new profile card component
+
+```swift
+// 1. Create the view
+struct ProfileCard: View {
+    let name: String
+    let avatar: String
+
+    var body: some View {
+        HStack {
+            Image(systemName: avatar)
+                .font(.largeTitle)
+            Text(name)
+                .font(.headline)
+        }
+        .padding()
+        .background(Color.gray.opacity(0.1))
+        .cornerRadius(8)
+    }
+}
+
+// 2. Add to Storybook with unique dev tag
+extension Storybook {
+    @objc static let profileCard = StorybookPage(
+        folder: "/Components/Profile",
+        views: [
+            ProfileCard(name: "John Doe", avatar: "person.circle")
+                .storybookTitle("Default State")
+                .storybookTags("dev-a7c8f3e1"),  // ← Unique tag
+            ProfileCard(name: "Jane Smith", avatar: "person.circle.fill")
+                .storybookTitle("Filled Avatar")
+                .storybookTags("profile-card")   // ← Semantic tag (stays)
+        ]
+    )
+}
+
+// 3. Launch app with --storybook argument
+// 4. Search: #dev-a7c8f3e1
+// 5. View opens automatically
+// 6. Iterate: make changes → hot reload → verify
+// 7. Before commit: remove dev-a7c8f3e1 tag, keep profile-card tag
+```
+
+## Tag Management Strategy
+
+### Temporary Dev Tags
+- Format: `dev-{short-uuid}`
+- Purpose: Navigate during active development
+- Lifecycle: Add when starting work, remove before commit
+- Unique per development session
+
+### Permanent Semantic Tags
+- Format: Descriptive names (`button`, `primary-cta`, `error-state`)
+- Purpose: Organize and categorize components
+- Lifecycle: Commit with the code
+- Shared across similar components
+
+```swift
+// Good: Both temporary and permanent tags
+.storybookTags("dev-3f1b16a2", "button", "primary-cta")
+
+// During dev: search #dev-3f1b16a2 (unique, auto-navigates)
+// After dev: search #button or #primary-cta (find related components)
+```
+
+## Common Mistakes
+
+### ❌ Using Non-Unique Tags for Dev
+```swift
+.storybookTags("button")  // Too many results, no auto-navigation
+```
+**Fix:** Use UUID-based tag for development work
+
+### ❌ Forgetting to Remove Dev Tags
+```swift
+.storybookTags("dev-a7c8f3e1")  // ← Still in code after commit
+```
+**Fix:** Always clean up dev tags before committing. Semantic tags should stay.
+
+### ❌ Not Setting Up Launch Argument
+Running full app → navigating to test → finding Storybook
+**Fix:** Configure `--storybook` argument to launch directly
+
+### ❌ Reusing Same Dev Tag
+Using `dev-current` for multiple views across sessions
+**Fix:** Generate fresh UUID for each new development task
+
+## Integration with Development Workflow
+
+### For AI Agents
+
+When implementing UI changes:
+1. Generate unique tag: `tag=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)`
+2. Add to view: `.storybookTags("dev-$tag")`
+3. Build/run with `--storybook`
+4. Search `#dev-$tag` to verify
+5. Iterate until correct
+6. Remove dev tag before completion
+
+### For Human Developers
+
+**During development:**
+- Enable Storybook scheme
+- Add dev tag to view you're working on
+- Search tag whenever you rebuild
+- Visual feedback loop is immediate
+
+**Before commit:**
+- Review diffs for any `dev-` tags
+- Remove temporary tags
+- Keep semantic tags for organization
+
+## Troubleshooting
+
+**View doesn't auto-open:**
+- Ensure tag is truly unique (only one view has it)
+- Check search includes `#` prefix
+- Verify tag search returns exactly 1 result
+
+**Can't find view:**
+- Confirm view is added to Storybook extension
+- Check tag spelling matches exactly
+- Try searching without `#` to see all matches
+
+**Launch argument not working:**
+- Verify scheme has `--storybook` argument
+- Check argument is enabled (checked)
+- Ensure app code checks `ProcessInfo.processInfo.arguments`


### PR DESCRIPTION
Adds the ability to tag views with string values. This allows a more robust search in cases where the view names do not match what people refer to the views as. This is helpful when working with design systems so both technical names and non technical names can refer to the same views. 